### PR TITLE
Add Tweakable Resource Limits

### DIFF
--- a/charts/identity/templates/_helpers.tpl
+++ b/charts/identity/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Create the container images
 */}}
 {{- define "unikorn.image" -}}
-{{- .Values.image | default (printf "%s/unikorn-identity:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
+{{- .Values.server.image | default (printf "%s/unikorn-identity:%s" (include "unikorn.defaultRepositoryPath" .) (.Values.tag | default .Chart.Version)) }}
 {{- end }}
 
 {{- define "unikorn.organizationControllerImage" -}}

--- a/charts/identity/templates/identity/deployment.yaml
+++ b/charts/identity/templates/identity/deployment.yaml
@@ -69,12 +69,7 @@ spec:
         - name: http
           containerPort: 6080
         resources:
-          requests:
-            cpu: "50m"
-            memory: 50Mi
-          limits:
-            cpu: "100m"
-            memory: 100Mi
+          {{- .Values.server.resources | toYaml | nindent 10 }}
         securityContext:
           readOnlyRootFilesystem: true
       serviceAccountName: {{ .Release.Name }}-server

--- a/charts/identity/templates/oauth2client-controller/deployment.yaml
+++ b/charts/identity/templates/oauth2client-controller/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "unikorn.core.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
         resources:
-          requests:
-            cpu: 50m
-            memory: 50Mi
-          limits:
-            cpu: 100m
-            memory: 100Mi
+          {{- .Values.oauth2clientController.resources | toYaml | nindent 10 }}
         securityContext:
           readOnlyRootFilesystem: true
       serviceAccountName: {{ .Release.Name }}-oauth2client-controller

--- a/charts/identity/templates/organization-controller/deployment.yaml
+++ b/charts/identity/templates/organization-controller/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "unikorn.core.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
         resources:
-          requests:
-            cpu: 50m
-            memory: 50Mi
-          limits:
-            cpu: 100m
-            memory: 100Mi
+          {{- .Values.organizationController.resources | toYaml | nindent 10 }}
         securityContext:
           readOnlyRootFilesystem: true
       serviceAccountName: {{ .Release.Name }}-organization-controller

--- a/charts/identity/templates/project-controller/deployment.yaml
+++ b/charts/identity/templates/project-controller/deployment.yaml
@@ -21,12 +21,7 @@ spec:
         {{- include "unikorn.core.flags" . | nindent 8 }}
         {{- include "unikorn.otlp.flags" . | nindent 8 }}
         resources:
-          requests:
-            cpu: 50m
-            memory: 50Mi
-          limits:
-            cpu: 100m
-            memory: 100Mi
+          {{- .Values.projectController.resources | toYaml | nindent 10 }}
         securityContext:
           readOnlyRootFilesystem: true
       serviceAccountName: {{ .Release.Name }}-project-controller

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -12,23 +12,49 @@ tag: ~
 # Set the image pull secret on the service accounts of all the controllers.
 imagePullSecret: ~
 
-# Allows override of the global default image.
-image: ~
+# Allows override of the identity service configuration.
+server:
+  # Allows override of the image.
+  image: ~
+
+  # Allows resource limits to be set.
+  resources:
+    limits:
+      cpu: '1'
+      memory: 1Gi
 
 # Organization controller specifc configuration.
 organizationController:
-  # Allows override of the global default image.
+  # Allows override of the image.
   image:
+
+  # Allows resource limits to be set.
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
 
 # Oauth2 client controller specific configuration.
 oauth2clientController:
-  # Allows override of the global default image.
+  # Allows override of the image.
   image:
+
+  # Allows resource limits to be set.
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
 
 # Project controller specific configuration.
 projectController:
-  # Allows override of the global default image.
+  # Allows override of the image.
   image:
+
+  # Allows resource limits to be set.
+  resources:
+    limits:
+      cpu: 100m
+      memory: 100Mi
 
 # Sets the DNS hosts, X.509 certificate subject alternative names and
 # oauth2 issuer etc.


### PR DESCRIPTION
Allow all services to have their resource allocations modified.  This mostly keeps things as they were, but only specifies limits not for guaranteed QoS scheduling.  The identity server has been expanded by 10x as memory utilization does tend to increase quickly when placed on the public internet!  The long term solution to growing numbers of resources and cache sizes is probably an external database, however that breaks the whole cascading cleanup thing when using namespaces...