### PR TITLE
Allow OAuth2 Secrets from Secrets

### DIFF
--- a/charts/identity/crds/identity.unikorn-cloud.org_oauth2providers.yaml
+++ b/charts/identity/crds/identity.unikorn-cloud.org_oauth2providers.yaml
@@ -56,7 +56,7 @@ spec:
               OAuth2ProviderSpec defines the required configuration for an oauth2
               provider.
             properties:
-              authorizatonURI:
+              authorizationURI:
                 description: AuthorizationURI is used when OIDC (discovery) is not
                   available.
                 type: string
@@ -65,6 +65,12 @@ spec:
                 type: string
               clientSecret:
                 description: ClientSecret is created by the IdP for token exchange.
+                type: string
+              clientSecretName:
+                description: |-
+                  ClientSecretName if set overrides ClientSecret and sources the client
+                  ID and secret from a Kubernetes secret, stored under the "id" and
+                  "secret" keys respectively.
                 type: string
               issuer:
                 description: |-
@@ -105,7 +111,6 @@ spec:
                 - github
                 type: string
             required:
-            - clientID
             - issuer
             type: object
           status:

--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -111,6 +111,9 @@ issuer:
 #     clientID: foo.apps.googleusercontent.com
 #     # The client secret assigned by the identity provider.
 #     clientSecret: something_from_google
+#     # The client ID and secret, sourced as a secret.
+#     # They must have the keys "id" and "secret",
+#     clientSecretName: my-client-secret-secret
 
 # platformAdministratorRole is a role that can be implicitly added to users
 # and service accounts.

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -122,11 +122,15 @@ type OAuth2ProviderSpec struct {
 	// This will be used to verify issued JWTs have the same "iss" claim.
 	Issuer string `json:"issuer"`
 	// ClientID is the assigned client identifier.
-	ClientID string `json:"clientID"`
+	ClientID string `json:"clientID,omitempty"`
 	// ClientSecret is created by the IdP for token exchange.
 	ClientSecret string `json:"clientSecret,omitempty"`
+	// ClientSecretName if set overrides ClientSecret and sources the client
+	// ID and secret from a Kubernetes secret, stored under the "id" and
+	// "secret" keys respectively.
+	ClientSecretName string `json:"clientSecretName,omitempty"`
 	// AuthorizationURI is used when OIDC (discovery) is not available.
-	AuthorizationURI *string `json:"authorizatonURI,omitempty"`
+	AuthorizationURI *string `json:"authorizationURI,omitempty"`
 	// TokenURI is used when OIDC (discovery) is not available.
 	TokenURI *string `json:"tokenURI,omitempty"`
 }

--- a/pkg/oauth2/providers/github/provider.go
+++ b/pkg/oauth2/providers/github/provider.go
@@ -29,6 +29,8 @@ import (
 	"github.com/unikorn-cloud/identity/pkg/oauth2/common"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/oidc"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -157,16 +159,16 @@ func New() *Provider {
 	return &Provider{}
 }
 
-func (*Provider) Config(ctx context.Context, parameters *types.ConfigParameters) (*oauth2.Config, error) {
-	return common.Config(parameters, nil), nil
+func (*Provider) Config(ctx context.Context, client client.Client, parameters *types.ConfigParameters) (*oauth2.Config, error) {
+	return common.Config(ctx, client, parameters, nil)
 }
 
 func (*Provider) AuthorizationURL(config *oauth2.Config, parameters *types.AuthorizationParamters) (string, error) {
 	return common.Authorization(config, parameters, nil), nil
 }
 
-func (*Provider) CodeExchange(ctx context.Context, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error) {
-	token, err := common.CodeExchange(ctx, parameters)
+func (*Provider) CodeExchange(ctx context.Context, client client.Client, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error) {
+	token, err := common.CodeExchange(ctx, client, parameters)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/oauth2/providers/google/provider.go
+++ b/pkg/oauth2/providers/google/provider.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/unikorn-cloud/identity/pkg/oauth2/oidc"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Provider struct{}
@@ -31,8 +33,8 @@ func New() *Provider {
 	return &Provider{}
 }
 
-func (*Provider) Config(ctx context.Context, parameters *types.ConfigParameters) (*oauth2.Config, error) {
-	_, config, err := oidc.Config(ctx, parameters, nil)
+func (*Provider) Config(ctx context.Context, client client.Client, parameters *types.ConfigParameters) (*oauth2.Config, error) {
+	_, config, err := oidc.Config(ctx, client, parameters, nil)
 
 	return config, err
 }
@@ -48,6 +50,6 @@ func (*Provider) AuthorizationURL(config *oauth2.Config, parameters *types.Autho
 	return oidc.Authorization(config, parameters, nil)
 }
 
-func (*Provider) CodeExchange(ctx context.Context, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error) {
-	return oidc.CodeExchange(ctx, parameters)
+func (*Provider) CodeExchange(ctx context.Context, client client.Client, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error) {
+	return oidc.CodeExchange(ctx, client, parameters)
 }

--- a/pkg/oauth2/providers/interfaces.go
+++ b/pkg/oauth2/providers/interfaces.go
@@ -23,13 +23,15 @@ import (
 
 	"github.com/unikorn-cloud/identity/pkg/oauth2/oidc"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Provider interface {
 	// Config returns an oauth2 configuration.
-	Config(ctx context.Context, parameters *types.ConfigParameters) (*oauth2.Config, error)
+	Config(ctx context.Context, client client.Client, parameters *types.ConfigParameters) (*oauth2.Config, error)
 	// Authorization gets the oauth2 authorization URL.
 	AuthorizationURL(config *oauth2.Config, parameters *types.AuthorizationParamters) (string, error)
 	// CodeExchange exchanges a code with an oauth2 server and returns a (possibly emulated) OIDC ID token.
-	CodeExchange(ctx context.Context, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error)
+	CodeExchange(ctx context.Context, client client.Client, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error)
 }

--- a/pkg/oauth2/providers/microsoft/provider.go
+++ b/pkg/oauth2/providers/microsoft/provider.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/unikorn-cloud/identity/pkg/oauth2/oidc"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type Provider struct{}
@@ -32,7 +34,7 @@ func New() *Provider {
 	return &Provider{}
 }
 
-func (*Provider) Config(ctx context.Context, parameters *types.ConfigParameters) (*oauth2.Config, error) {
+func (*Provider) Config(ctx context.Context, client client.Client, parameters *types.ConfigParameters) (*oauth2.Config, error) {
 	// Handle non-stardard issuers.
 	ctx = gooidc.InsecureIssuerURLContext(ctx, "https://login.microsoftonline.com/{tenantid}/v2.0")
 
@@ -40,7 +42,7 @@ func (*Provider) Config(ctx context.Context, parameters *types.ConfigParameters)
 	// See https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-auth-code-flow.
 	// scopes := []string{"offline_access"}
 
-	_, config, err := oidc.Config(ctx, parameters, nil)
+	_, config, err := oidc.Config(ctx, client, parameters, nil)
 
 	return config, err
 }
@@ -49,11 +51,11 @@ func (*Provider) AuthorizationURL(config *oauth2.Config, parameters *types.Autho
 	return oidc.Authorization(config, parameters, nil)
 }
 
-func (*Provider) CodeExchange(ctx context.Context, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error) {
+func (*Provider) CodeExchange(ctx context.Context, client client.Client, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error) {
 	// Handle non-stardard issuers.
 	ctx = gooidc.InsecureIssuerURLContext(ctx, "https://login.microsoftonline.com/{tenantid}/v2.0")
 
 	parameters.SkipIssuerCheck = true
 
-	return oidc.CodeExchange(ctx, parameters)
+	return oidc.CodeExchange(ctx, client, parameters)
 }

--- a/pkg/oauth2/providers/null.go
+++ b/pkg/oauth2/providers/null.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/unikorn-cloud/identity/pkg/oauth2/oidc"
 	"github.com/unikorn-cloud/identity/pkg/oauth2/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // nullProvider does nothing.
@@ -32,8 +34,8 @@ func newNullProvider() Provider {
 	return &nullProvider{}
 }
 
-func (*nullProvider) Config(ctx context.Context, parameters *types.ConfigParameters) (*oauth2.Config, error) {
-	_, config, err := oidc.Config(ctx, parameters, nil)
+func (*nullProvider) Config(ctx context.Context, client client.Client, parameters *types.ConfigParameters) (*oauth2.Config, error) {
+	_, config, err := oidc.Config(ctx, client, parameters, nil)
 
 	return config, err
 }
@@ -42,6 +44,6 @@ func (*nullProvider) AuthorizationURL(config *oauth2.Config, parameters *types.A
 	return oidc.Authorization(config, parameters, nil)
 }
 
-func (*nullProvider) CodeExchange(ctx context.Context, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error) {
-	return oidc.CodeExchange(ctx, parameters)
+func (*nullProvider) CodeExchange(ctx context.Context, client client.Client, parameters *types.CodeExchangeParameters) (*oauth2.Token, *oidc.IDToken, error) {
+	return oidc.CodeExchange(ctx, client, parameters)
 }

--- a/pkg/oauth2/types/types.go
+++ b/pkg/oauth2/types/types.go
@@ -35,9 +35,9 @@ type ConfigParameters struct {
 type AuthorizationParamters struct {
 	// State is the state that's preserved across the authorization.
 	State string
-	// CodeChallenge is the PKCE code challenge used to compare against
+	// CodeVerifier is the PKCE code verifier used to compare against
 	// the one supplied during exchange. OIDC only.
-	CodeChallenge string
+	CodeVerifier string
 	// Nonce is the single use value required by OIDC that's encoded
 	// in the id_token.  OIDC only.
 	Nonce string


### PR DESCRIPTION
Allows the clinet ID and secret to be read from a secret, for example provided by external secrets operator.  Most of this is just tweaking the interfaces to propagate the clients to where they are needed, then just using literals or the secret.  Spotted a few library calls that can replace some exsting configuration, and where we were specifiying things that are implictly added.  Also fixed a typo in the API, so that needs calling out.

Fixes #279.