### PR TITLE
Fix Allocation Updates

### DIFF
--- a/pkg/handler/allocations/client.go
+++ b/pkg/handler/allocations/client.go
@@ -253,7 +253,7 @@ func (c *Client) Update(ctx context.Context, organizationID, projectID, allocati
 		return nil, err
 	}
 
-	if err := conversion.UpdateObjectMetadata(required, current, nil, nil); err != nil {
+	if err := conversion.UpdateObjectMetadata(required, current); err != nil {
 		return nil, errors.OAuth2ServerError("failed to merge metadata").WithError(err)
 	}
 


### PR DESCRIPTION
The object metadata interface updated to be more flexible, but as a result the old parameters (when nil) are still valid as callbacks, which results in a null pointer dereference.  Remove these nulls.  I have grepped everything, so this is definitely the last!!