### PR TITLE
Use Service Descriptors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
-	github.com/unikorn-cloud/core v1.8.1-0.20251006101047-07583c8f1ccd
+	github.com/unikorn-cloud/core v1.8.1-0.20251006115257-4e7559092b79
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/sdk v1.35.0
 	go.opentelemetry.io/otel/trace v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -137,8 +137,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
-github.com/unikorn-cloud/core v1.8.1-0.20251006101047-07583c8f1ccd h1:1E19ZVvKeRZErBCiu8DP0UL//f6JZPjuLw46lBl+oao=
-github.com/unikorn-cloud/core v1.8.1-0.20251006101047-07583c8f1ccd/go.mod h1:KZLGw/EyZWjem4c80QF70KqpHIT7MAk7o6L4VAWsnGM=
+github.com/unikorn-cloud/core v1.8.1-0.20251006115257-4e7559092b79 h1:3CErNSv78yyooSKRqyUCaV9ytHjQzU4d5IimdUOIlkQ=
+github.com/unikorn-cloud/core v1.8.1-0.20251006115257-4e7559092b79/go.mod h1:KZLGw/EyZWjem4c80QF70KqpHIT7MAk7o6L4VAWsnGM=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 	"path"
+
+	"github.com/unikorn-cloud/core/pkg/util"
 )
 
 var (
@@ -42,4 +44,12 @@ var (
 // call out ot other micro services.
 func VersionString() string {
 	return fmt.Sprintf("%s/%s (revision/%s)", Application, Version, Revision)
+}
+
+func ServiceDescriptor() util.ServiceDescriptor {
+	return util.ServiceDescriptor{
+		Name:     Application,
+		Version:  Version,
+		Revision: Revision,
+	}
 }

--- a/pkg/controllers/oauth2client/manager.go
+++ b/pkg/controllers/oauth2client/manager.go
@@ -20,6 +20,7 @@ import (
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	coremanager "github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/manager/options"
+	"github.com/unikorn-cloud/core/pkg/util"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/identity/pkg/constants"
 	"github.com/unikorn-cloud/identity/pkg/provisioners/oauth2client"
@@ -38,8 +39,8 @@ type Factory struct{}
 var _ coremanager.ControllerFactory = &Factory{}
 
 // Metadata returns the application, version and revision.
-func (*Factory) Metadata() (string, string, string) {
-	return constants.Application, constants.Version, constants.Revision
+func (*Factory) Metadata() util.ServiceDescriptor {
+	return constants.ServiceDescriptor()
 }
 
 // Options returns any options to be added to the CLI flags and passed to the reconciler.

--- a/pkg/controllers/organization/manager.go
+++ b/pkg/controllers/organization/manager.go
@@ -21,6 +21,7 @@ import (
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	coremanager "github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/manager/options"
+	"github.com/unikorn-cloud/core/pkg/util"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/identity/pkg/constants"
 	"github.com/unikorn-cloud/identity/pkg/provisioners/organization"
@@ -39,8 +40,8 @@ type Factory struct{}
 var _ coremanager.ControllerFactory = &Factory{}
 
 // Metadata returns the application, version and revision.
-func (*Factory) Metadata() (string, string, string) {
-	return constants.Application, constants.Version, constants.Revision
+func (*Factory) Metadata() util.ServiceDescriptor {
+	return constants.ServiceDescriptor()
 }
 
 // Options returns any options to be added to the CLI flags and passed to the reconciler.

--- a/pkg/controllers/project/manager.go
+++ b/pkg/controllers/project/manager.go
@@ -21,6 +21,7 @@ import (
 	coreclient "github.com/unikorn-cloud/core/pkg/client"
 	coremanager "github.com/unikorn-cloud/core/pkg/manager"
 	"github.com/unikorn-cloud/core/pkg/manager/options"
+	"github.com/unikorn-cloud/core/pkg/util"
 	unikornv1 "github.com/unikorn-cloud/identity/pkg/apis/unikorn/v1alpha1"
 	"github.com/unikorn-cloud/identity/pkg/constants"
 	"github.com/unikorn-cloud/identity/pkg/provisioners/project"
@@ -39,8 +40,8 @@ type Factory struct{}
 var _ coremanager.ControllerFactory = &Factory{}
 
 // Metadata returns the application, version and revision.
-func (*Factory) Metadata() (string, string, string) {
-	return constants.Application, constants.Version, constants.Revision
+func (*Factory) Metadata() util.ServiceDescriptor {
+	return constants.ServiceDescriptor()
 }
 
 // Options returns any options to be added to the CLI flags and passed to the reconciler.


### PR DESCRIPTION
THis updates the core library to pick up shared service descriptor types that can be used to simplify log intitialization and providing metadata to tracing calls.